### PR TITLE
Change description of lastpass-cli

### DIFF
--- a/lastpass-cli/recipe.rb
+++ b/lastpass-cli/recipe.rb
@@ -13,7 +13,7 @@ class LastPassCli < FPM::Cookery::Recipe
     :with => 'git',
     :tag  => "v#{version}"
 
-  description 'A fast and easy-to-use status bar'
+  description 'LastPass command line interface tool'
 
   build_depends 'libcurl4-openssl-dev',
     'libssl-dev',


### PR DESCRIPTION
Grabbed the description from the lpass-cli github repo description.

Fixes #4 

Now that I actually want to use this package, it provides me an eyetwitch.