### PR TITLE
Update Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 ---
-dist: trusty
+dist: xenial
 sudo: required
 language: ruby
-rvm: 2.1.10
+rvm:
+  - 2.5
 cache: bundler
 service:
   - docker

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake', '< 12'
+gem 'rake', '>= 12.3.3'
+gem 'ffi', '1.9.18'
 
 group :deployment do
   gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: https://github.com/bernd/fpm-cookery.git
-  revision: 051cc162f874bfc026b6bc051606d5b8813c1f06
+  revision: 07f06f03ee9a06c48ea0635b9fc33ffe1844d19f
   branch: master
   specs:
-    fpm-cookery (0.33.0)
+    fpm-cookery (0.35.1)
       addressable (~> 2.3.8)
       facter
       fpm (~> 1.1)
       json (>= 1.7.7, < 2.0)
       json_pure (>= 1.7.7, < 2.0)
-      puppet (~> 3.4)
+      puppet (>= 3.4, < 6.0)
       safe_yaml (~> 1.0.4)
       systemu
 
@@ -19,52 +19,60 @@ GEM
     addressable (2.3.8)
     arr-pm (0.0.10)
       cabin (> 0)
-    backports (3.11.4)
+    backports (3.17.1)
     cabin (0.9.0)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
-    dotenv (2.5.0)
+    dotenv (2.7.5)
     dpkg-deb (0.1.0)
-    facter (2.5.1)
-    ffi (1.9.25)
-    fpm (1.10.2)
+    facter (2.5.7)
+    fast_gettext (1.1.2)
+    ffi (1.9.18)
+    fpm (1.11.0)
       arr-pm (~> 0.0.10)
       backports (>= 2.6.2)
       cabin (>= 0.6.0)
-      childprocess
+      childprocess (= 0.9.0)
       clamp (~> 1.0.0)
       ffi
       json (>= 1.7.7, < 2.0)
       pleaserun (~> 0.0.29)
       ruby-xz (~> 0.2.3)
       stud
-    hiera (1.3.4)
-      json_pure
-    httparty (0.16.2)
+    hiera (3.6.0)
+    httparty (0.18.0)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     insist (1.0.0)
-    io-like (0.3.0)
+    io-like (0.3.1)
     json (1.8.6)
     json_pure (1.8.6)
+    locale (2.1.3)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
+    multi_json (1.14.1)
     multi_xml (0.6.0)
     mustache (0.99.8)
-    pleaserun (0.0.30)
+    pleaserun (0.0.31)
       cabin (> 0)
       clamp
       dotenv
       insist
       mustache (= 0.99.8)
       stud
-    puppet (3.8.7)
-      facter (> 1.6, < 3)
-      hiera (~> 1.0)
-      json_pure
-    rake (11.3.0)
+    puppet (5.5.19)
+      facter (> 2.0.1, < 4)
+      fast_gettext (~> 1.1.2)
+      hiera (>= 3.2.1, < 4)
+      locale (~> 2.1)
+      multi_json (~> 1.10)
+    rake (13.0.1)
     ruby-xz (0.2.3)
       ffi (~> 1.9)
       io-like (~> 0.3)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     stud (0.0.23)
     systemu (2.6.5)
     xmlrpc (0.3.0)
@@ -74,10 +82,11 @@ PLATFORMS
 
 DEPENDENCIES
   dpkg-deb
+  ffi (= 1.9.18)
   fpm-cookery!
   httparty
-  rake (< 12)
+  rake (>= 12.3.3)
   xmlrpc
 
 BUNDLED WITH
-   1.16.1
+   2.1.4


### PR DESCRIPTION
* Update `rake` version to address vulnerabilities
* Update `fpm-cookery` to latest version
* pin `ffi` to `1.9.18` since that's the last version that works with libffi6